### PR TITLE
Add bookmark tools and request helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The following endpoints from the API have been made available as tools, that LLM
 ### Languages
 * GET /resources/languages - Get all languages
 
+### Bookmarks
+* GET /user/bookmarks - List user bookmarks
+* POST /user/bookmarks - Add bookmark
+* DELETE /user/bookmarks/{id} - Delete bookmark
+Authentication headers `x-auth-token` and `x-client-id` must be supplied via the corresponding environment variables.
+
 ## Setup
 
 ### Requirements
@@ -129,8 +135,12 @@ To use this MCP server with Claude Desktop, add the following configuration to y
 ## Environment Variables
 
 * `API_KEY`: API key for authentication
+* `AUTH_TOKEN`: OAuth token for user endpoints (required for bookmark tools)
+* `CLIENT_ID`: OAuth client ID associated with the token
 * `PORT`: Server port (default: 8000 or 3000 depending on language)
 * `VERBOSE_MODE`: Set to 'true' to enable verbose logging of API requests and responses (default: false)
+
+`AUTH_TOKEN` and `CLIENT_ID` must be provided to use the bookmark-related tools.
 
 ## Verbose Mode
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,8 @@
 // Environment variables
 export const VERBOSE_MODE = process.env.VERBOSE_MODE === 'true';
 export const API_KEY = process.env.API_KEY || '';
+export const AUTH_TOKEN = process.env.AUTH_TOKEN || '';
+export const CLIENT_ID = process.env.CLIENT_ID || '';
 
 // API configuration
 export const API_BASE_URL = 'https://api.quran.com/api/v4';

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -363,4 +363,26 @@ export const toolExamples = {
       }
     }
   ]
+  ,
+  'add-user-bookmark': [
+    {
+      description: 'Bookmark verse 1:1',
+      parameters: { verse_key: '1:1' },
+      result: { success: true, message: 'add-bookmark executed successfully', data: { id: 1 } }
+    }
+  ],
+  'list-user-bookmarks': [
+    {
+      description: 'List bookmarks',
+      parameters: {},
+      result: { success: true, message: 'list-bookmarks executed successfully', data: { bookmarks: [] } }
+    }
+  ],
+  'delete-user-bookmark': [
+    {
+      description: 'Delete bookmark',
+      parameters: { id: 1 },
+      result: { success: true, message: 'delete-bookmark executed successfully', data: {} }
+    }
+  ]
 };

--- a/src/handlers/bookmarks.ts
+++ b/src/handlers/bookmarks.ts
@@ -1,0 +1,57 @@
+/**
+ * Bookmark handlers for the Quran.com API MCP Server
+ */
+
+import { z } from 'zod';
+import { verboseLog } from '../utils/logger';
+import { bookmarksService } from '../services';
+import {
+  addBookmarkSchema,
+  listBookmarksSchema,
+  deleteBookmarkSchema,
+} from '../schemas/bookmarks';
+
+export async function handleAddBookmark(args: any) {
+  try {
+    const validated = addBookmarkSchema.parse(args);
+    const result = await bookmarksService.addBookmark(validated);
+    verboseLog('response', { tool: 'add-user-bookmark', result });
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (error) {
+    verboseLog('error', { tool: 'add-user-bookmark', error: error instanceof Error ? error.message : String(error) });
+    if (error instanceof z.ZodError) {
+      return { content: [{ type: 'text', text: `Validation error: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}` }], isError: true };
+    }
+    return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }], isError: true };
+  }
+}
+
+export async function handleGetBookmarks(args: any) {
+  try {
+    const validated = listBookmarksSchema.parse(args);
+    const result = await bookmarksService.getBookmarks(validated);
+    verboseLog('response', { tool: 'list-user-bookmarks', result });
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (error) {
+    verboseLog('error', { tool: 'list-user-bookmarks', error: error instanceof Error ? error.message : String(error) });
+    if (error instanceof z.ZodError) {
+      return { content: [{ type: 'text', text: `Validation error: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}` }], isError: true };
+    }
+    return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }], isError: true };
+  }
+}
+
+export async function handleDeleteBookmark(args: any) {
+  try {
+    const validated = deleteBookmarkSchema.parse(args);
+    const result = await bookmarksService.deleteBookmark(validated);
+    verboseLog('response', { tool: 'delete-user-bookmark', result });
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (error) {
+    verboseLog('error', { tool: 'delete-user-bookmark', error: error instanceof Error ? error.message : String(error) });
+    if (error instanceof z.ZodError) {
+      return { content: [{ type: 'text', text: `Validation error: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}` }], isError: true };
+    }
+    return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }], isError: true };
+  }
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -33,3 +33,10 @@ export {
   handleRecitationStyles,
   handleLanguages
 } from './resources';
+
+// Bookmark-related handlers
+export {
+  handleAddBookmark,
+  handleGetBookmarks,
+  handleDeleteBookmark,
+} from './bookmarks';

--- a/src/schemas/bookmarks.ts
+++ b/src/schemas/bookmarks.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const addBookmarkSchema = z.object({
+  verse_key: z.string().min(1).describe("Verse key like '1:1'")
+});
+
+export const listBookmarksSchema = z.object({});
+
+export const deleteBookmarkSchema = z.object({
+  id: z.number().int().positive().optional(),
+  verse_key: z.string().optional()
+}).refine(data => data.id || data.verse_key, { message: 'id or verse_key required' });
+
+export default {
+  addBookmark: addBookmarkSchema,
+  listBookmarks: listBookmarksSchema,
+  deleteBookmark: deleteBookmarkSchema,
+};

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -11,6 +11,7 @@ import juzsSchemas from './juzs';
 import languagesSchemas from './languages';
 import quranTextSchemas from './quran-text';
 import searchSchemas from './search';
+import bookmarksSchemas from './bookmarks';
 
 // Export all schemas
 export {
@@ -23,6 +24,7 @@ export {
   languagesSchemas,
   quranTextSchemas,
   searchSchemas,
+  bookmarksSchemas,
 };
 
 // Export individual schemas for direct imports
@@ -35,3 +37,4 @@ export * from './juzs';
 export * from './languages';
 export * from './quran-text';
 export * from './search';
+export * from './bookmarks';

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ const {
   tafsirsSchemas,
   audioSchemas,
   languagesSchemas,
+  bookmarksSchemas,
 } = require('./schemas');
 
 // Import handlers
@@ -59,6 +60,9 @@ const {
   handleChapterReciters,
   handleRecitationStyles,
   handleLanguages,
+  handleAddBookmark,
+  handleGetBookmarks,
+  handleDeleteBookmark,
 } = require('./handlers');
 
 // Import utilities
@@ -234,6 +238,22 @@ server.setRequestHandler(ListToolsRequestSchema, async (request: any) => ({
       inputSchema: zodToJsonSchema(languagesSchemas.languages),
       examples: toolExamples['languages'],
     },
+    // Bookmark-related tools
+    {
+      name: ApiTools.add_user_bookmark,
+      description: "Add a bookmark",
+      inputSchema: zodToJsonSchema(bookmarksSchemas.addBookmark),
+    },
+    {
+      name: ApiTools.list_user_bookmarks,
+      description: "List user bookmarks",
+      inputSchema: zodToJsonSchema(bookmarksSchemas.listBookmarks),
+    },
+    {
+      name: ApiTools.delete_user_bookmark,
+      description: "Delete a bookmark",
+      inputSchema: zodToJsonSchema(bookmarksSchemas.deleteBookmark),
+    },
   ],
 }));
 
@@ -304,11 +324,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
         return await handleChapterReciters(request.params.arguments);
       case ApiTools.recitation_styles:
         return await handleRecitationStyles(request.params.arguments);
-      
+
       // Language-related tools
       case ApiTools.languages:
         return await handleLanguages(request.params.arguments);
-      
+
+      // Bookmark-related tools
+      case ApiTools.add_user_bookmark:
+        return await handleAddBookmark(request.params.arguments);
+      case ApiTools.list_user_bookmarks:
+        return await handleGetBookmarks(request.params.arguments);
+      case ApiTools.delete_user_bookmark:
+        return await handleDeleteBookmark(request.params.arguments);
+
       default:
         throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${request.params.name}`);
     }

--- a/src/services/audio-service.ts
+++ b/src/services/audio-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL, CACHE_DURATION_MS } from '../config';
 import { 
   chapterRecitersSchema,
@@ -61,7 +61,7 @@ export class AudioService {
       try {
         // Make request to Quran.com API
         const url = `${API_BASE_URL}/resources/chapter_reciters`;
-        const response = await makeApiRequest(url, {
+        const response = await makeRequest("GET", url, {
           language: validatedParams.language
         });
         
@@ -156,7 +156,7 @@ export class AudioService {
       try {
         // Make request to Quran.com API
         const url = `${API_BASE_URL}/resources/recitation_styles`;
-        const response = await makeApiRequest(url);
+        const response = await makeRequest("GET", url);
         
         verboseLog('response', {
           method: 'listRecitationStyles',

--- a/src/services/base-service.ts
+++ b/src/services/base-service.ts
@@ -5,7 +5,7 @@
 import axios from 'axios';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { API_KEY, REQUEST_TIMEOUT_MS } from '../config';
+import { API_KEY, REQUEST_TIMEOUT_MS, AUTH_TOKEN, CLIENT_ID } from '../config';
 
 // Maximum number of retries for API requests
 const MAX_RETRIES = 3;
@@ -20,21 +20,33 @@ const INITIAL_RETRY_DELAY_MS = 1000;
  * @returns The API response data
  * @throws ApiError if the request fails after all retries
  */
-export async function makeApiRequest(
-  url: string, 
-  params: any = {}, 
+export async function makeRequest(
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+  url: string,
+  params: any = {},
+  data: any = {},
   retryCount: number = 0
 ): Promise<any> {
   try {
-    verboseLog('request', { 
-      url, 
+    verboseLog('request', {
+      method,
+      url,
       params,
+      data,
       retry: retryCount > 0 ? `Retry attempt ${retryCount} of ${MAX_RETRIES}` : undefined
     });
-    
-    const response = await axios.get(url, {
+
+    const headers: Record<string, string> = {};
+    if (API_KEY) headers['x-api-key'] = API_KEY;
+    if (AUTH_TOKEN) headers['x-auth-token'] = AUTH_TOKEN;
+    if (CLIENT_ID) headers['x-client-id'] = CLIENT_ID;
+
+    const response = await axios.request({
+      method,
+      url,
       params,
-      headers: API_KEY ? { 'x-api-key': API_KEY } : undefined,
+      data,
+      headers,
       timeout: REQUEST_TIMEOUT_MS
     });
     
@@ -71,7 +83,7 @@ export async function makeApiRequest(
       await new Promise(resolve => setTimeout(resolve, delay));
       
       // Retry the request with incremented retry count
-      return makeApiRequest(url, params, retryCount + 1);
+      return makeRequest(method, url, params, data, retryCount + 1);
     }
     
     if (axios.isAxiosError(error)) {
@@ -108,4 +120,15 @@ export async function makeApiRequest(
     
     throw error;
   }
+}
+
+/**
+ * Backwards compatible helper for GET requests
+ */
+export async function makeApiRequest(
+  url: string,
+  params: any = {},
+  retryCount: number = 0
+): Promise<any> {
+  return makeRequest('GET', url, params, {}, retryCount);
 }

--- a/src/services/bookmarks-service.ts
+++ b/src/services/bookmarks-service.ts
@@ -1,0 +1,79 @@
+/**
+ * Bookmarks-related services for the Quran.com API MCP Server
+ */
+
+import { z } from 'zod';
+import { ApiError } from '../types/error';
+import { verboseLog } from '../utils/logger';
+import { makeRequest } from './base-service';
+import { API_BASE_URL } from '../config';
+import {
+  addBookmarkSchema,
+  listBookmarksSchema,
+  deleteBookmarkSchema,
+} from '../schemas/bookmarks';
+import {
+  AddBookmarkResponse,
+  GetBookmarksResponse,
+  DeleteBookmarkResponse,
+} from '../types/api-responses';
+
+/** Service for user bookmark API operations */
+export class BookmarksService {
+  async addBookmark(params: z.infer<typeof addBookmarkSchema>): Promise<AddBookmarkResponse> {
+    try {
+      const validated = addBookmarkSchema.parse(params);
+      const url = `${API_BASE_URL}/user/bookmarks`;
+      const data = await makeRequest('POST', url, {}, validated);
+      return {
+        success: true,
+        message: 'add-bookmark executed successfully',
+        data,
+      };
+    } catch (error) {
+      verboseLog('error', { method: 'addBookmark', error: error instanceof Error ? error.message : String(error) });
+      if (error instanceof z.ZodError) {
+        throw new ApiError(`Validation error: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}`, 400);
+      }
+      throw error;
+    }
+  }
+
+  async getBookmarks(params: z.infer<typeof listBookmarksSchema>): Promise<GetBookmarksResponse> {
+    try {
+      const validated = listBookmarksSchema.parse(params);
+      const url = `${API_BASE_URL}/user/bookmarks`;
+      const data = await makeRequest('GET', url, validated);
+      return { success: true, message: 'list-bookmarks executed successfully', data };
+    } catch (error) {
+      verboseLog('error', { method: 'getBookmarks', error: error instanceof Error ? error.message : String(error) });
+      if (error instanceof z.ZodError) {
+        throw new ApiError(`Validation error: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}`, 400);
+      }
+      throw error;
+    }
+  }
+
+  async deleteBookmark(params: z.infer<typeof deleteBookmarkSchema>): Promise<DeleteBookmarkResponse> {
+    try {
+      const validated = deleteBookmarkSchema.parse(params);
+      let url = `${API_BASE_URL}/user/bookmarks`;
+      const query: any = {};
+      if (validated.id) {
+        url += `/${validated.id}`;
+      } else if (validated.verse_key) {
+        query.verse_key = validated.verse_key;
+      }
+      const data = await makeRequest('DELETE', url, query);
+      return { success: true, message: 'delete-bookmark executed successfully', data };
+    } catch (error) {
+      verboseLog('error', { method: 'deleteBookmark', error: error instanceof Error ? error.message : String(error) });
+      if (error instanceof z.ZodError) {
+        throw new ApiError(`Validation error: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}`, 400);
+      }
+      throw error;
+    }
+  }
+}
+
+export const bookmarksService = new BookmarksService();

--- a/src/services/chapters-service.ts
+++ b/src/services/chapters-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL, CACHE_DURATION_MS } from '../config';
 import { 
   listChaptersSchema, 
@@ -63,7 +63,7 @@ export class ChaptersService {
       try {
         // Make request to Quran.com API
         const url = `${API_BASE_URL}/chapters`;
-        const response = await makeApiRequest(url, {
+        const response = await makeRequest("GET", url, {
           language: validatedParams.language
         });
         
@@ -163,7 +163,7 @@ export class ChaptersService {
       const url = `${API_BASE_URL}/chapters/${chapterId}`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language
       });
       
@@ -208,7 +208,7 @@ export class ChaptersService {
       const url = `${API_BASE_URL}/chapters/${chapterId}/info`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language
       });
       

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -11,6 +11,7 @@ export { translationsService } from './translations-service';
 export { tafsirsService } from './tafsirs-service';
 export { audioService } from './audio-service';
 export { languagesService } from './languages-service';
+export { bookmarksService } from './bookmarks-service';
 
 // Export service classes for direct imports if needed
 export { ChaptersService } from './chapters-service';
@@ -21,6 +22,7 @@ export { TranslationsService } from './translations-service';
 export { TafsirsService } from './tafsirs-service';
 export { AudioService } from './audio-service';
 export { LanguagesService } from './languages-service';
+export { BookmarksService } from './bookmarks-service';
 
 // Export base service utilities
-export { makeApiRequest } from './base-service';
+export { makeRequest } from './base-service';

--- a/src/services/juzs-service.ts
+++ b/src/services/juzs-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL } from '../config';
 import { juzsSchema } from '../schemas/juzs';
 import { JuzsResponse } from '../types/api-responses';
@@ -30,7 +30,7 @@ export class JuzsService {
       const url = `${API_BASE_URL}/juzs`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {});
+      const data = await makeRequest("GET", url, {});
       
       return {
         success: true,

--- a/src/services/languages-service.ts
+++ b/src/services/languages-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL, CACHE_DURATION_MS } from '../config';
 import { languagesSchema } from '../schemas/languages';
 import { LanguagesResponse } from '../types/api-responses';
@@ -51,7 +51,7 @@ export class LanguagesService {
       try {
         // Make request to Quran.com API
         const url = `${API_BASE_URL}/resources/languages`;
-        const response = await makeApiRequest(url, {
+        const response = await makeRequest("GET", url, {
           language: validatedParams.language
         });
         

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL } from '../config';
 import { searchSchema } from '../schemas/search';
 import { SearchResponse } from '../types/api-responses';
@@ -29,7 +29,7 @@ export class SearchService {
       const url = `${API_BASE_URL}/search`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         q: validatedParams.q,
         size: validatedParams.size,
         page: validatedParams.page,

--- a/src/services/tafsirs-service.ts
+++ b/src/services/tafsirs-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL, CACHE_DURATION_MS } from '../config';
 import { 
   tafsirSchema, 
@@ -59,7 +59,7 @@ export class TafsirsService {
       try {
         // Make request to Quran.com API
         const url = `${API_BASE_URL}/resources/tafsirs`;
-        const response = await makeApiRequest(url, {
+        const response = await makeRequest("GET", url, {
           language: validatedParams.language
         });
         
@@ -143,7 +143,7 @@ export class TafsirsService {
       const url = `${API_BASE_URL}/resources/tafsirs/${validatedParams.tafsir_id}/info`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url);
+      const data = await makeRequest("GET", url);
       
       return {
         success: true,
@@ -197,7 +197,7 @@ export class TafsirsService {
       if (validatedParams.verse_key) queryParams.verse_key = validatedParams.verse_key;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, queryParams);
+      const data = await makeRequest("GET", url, queryParams);
       
       return {
         success: true,

--- a/src/services/translations-service.ts
+++ b/src/services/translations-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL, CACHE_DURATION_MS } from '../config';
 import { 
   translationSchema, 
@@ -59,7 +59,7 @@ export class TranslationsService {
       try {
         // Make request to Quran.com API
         const url = `${API_BASE_URL}/resources/translations`;
-        const response = await makeApiRequest(url, {
+        const response = await makeRequest("GET", url, {
           language: validatedParams.language
         });
         
@@ -143,7 +143,7 @@ export class TranslationsService {
       const url = `${API_BASE_URL}/resources/translations/${validatedParams.translation_id}/info`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url);
+      const data = await makeRequest("GET", url);
       
       return {
         success: true,

--- a/src/services/verses-service.ts
+++ b/src/services/verses-service.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { ApiError } from '../types/error';
 import { verboseLog } from '../utils/logger';
-import { makeApiRequest } from './base-service';
+import { makeRequest } from './base-service';
 import { API_BASE_URL } from '../config';
 import {
   versesByChapterNumberSchema,
@@ -46,7 +46,7 @@ export class VersesService {
       const url = `${API_BASE_URL}/verses/by_chapter/${validatedParams.chapter_number}`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language,
         words: validatedParams.words,
         translations: validatedParams.translations,
@@ -95,7 +95,7 @@ export class VersesService {
       const url = `${API_BASE_URL}/verses/by_page/${validatedParams.page_number}`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language,
         words: validatedParams.words,
         translations: validatedParams.translations,
@@ -144,7 +144,7 @@ export class VersesService {
       const url = `${API_BASE_URL}/verses/by_juz/${validatedParams.juz_number}`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language,
         words: validatedParams.words,
         translations: validatedParams.translations,
@@ -193,7 +193,7 @@ export class VersesService {
       const url = `${API_BASE_URL}/verses/by_hizb/${validatedParams.hizb_number}`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language,
         words: validatedParams.words,
         translations: validatedParams.translations,
@@ -242,7 +242,7 @@ export class VersesService {
       const url = `${API_BASE_URL}/verses/by_rub/${validatedParams.rub_el_hizb_number}`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language,
         words: validatedParams.words,
         translations: validatedParams.translations,
@@ -289,7 +289,7 @@ export class VersesService {
       const url = `${API_BASE_URL}/verses/by_key/${validatedParams.verse_key}`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language,
         words: validatedParams.words,
         translations: validatedParams.translations,
@@ -336,7 +336,7 @@ export class VersesService {
       const url = `${API_BASE_URL}/verses/random`;
       
       // Make request to Quran.com API
-      const data = await makeApiRequest(url, {
+      const data = await makeRequest("GET", url, {
         language: validatedParams.language,
         words: validatedParams.words,
         translations: validatedParams.translations,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -47,6 +47,9 @@ export const ApiTools = {
   QURAN_verses_code_v1: "QURAN-verses-code_v1",
   QURAN_verses_code_v2: "QURAN-verses-code_v2",
   search: "search",
+  add_user_bookmark: "add-user-bookmark",
+  list_user_bookmarks: "list-user-bookmarks",
+  delete_user_bookmark: "delete-user-bookmark",
 } as const;
 
 // Create a type from the object values
@@ -111,6 +114,11 @@ export const ToolCategories = {
     ApiTools.QURAN_verses_Imlaei,
     ApiTools.QURAN_verses_code_v1,
     ApiTools.QURAN_verses_code_v2,
+  ],
+  bookmarks: [
+    ApiTools.add_user_bookmark,
+    ApiTools.list_user_bookmarks,
+    ApiTools.delete_user_bookmark,
   ],
   search: [
     ApiTools.search,

--- a/src/types/api-responses.ts
+++ b/src/types/api-responses.ts
@@ -90,3 +90,10 @@ export interface QuranVersesCodeV2Response extends BaseApiResponse {}
  * Search-related response interfaces
  */
 export interface SearchResponse extends BaseApiResponse {}
+
+/**
+ * Bookmark-related response interfaces
+ */
+export interface AddBookmarkResponse extends BaseApiResponse {}
+export interface GetBookmarksResponse extends BaseApiResponse {}
+export interface DeleteBookmarkResponse extends BaseApiResponse {}

--- a/tests/bookmarks.test.ts
+++ b/tests/bookmarks.test.ts
@@ -1,0 +1,29 @@
+import { BookmarksService } from '../src/services/bookmarks-service';
+import { makeRequest } from '../src/services/base-service';
+import { handleAddBookmark } from '../src/handlers/bookmarks';
+
+jest.mock('../src/services/base-service', () => ({
+  makeRequest: jest.fn(),
+}));
+
+const mockedMakeRequest = makeRequest as jest.MockedFunction<typeof makeRequest>;
+
+describe('BookmarksService', () => {
+  const service = new BookmarksService();
+  beforeEach(() => {
+    mockedMakeRequest.mockReset();
+    mockedMakeRequest.mockResolvedValue({ ok: true });
+  });
+
+  it('calls makeRequest when adding bookmark', async () => {
+    await service.addBookmark({ verse_key: '1:1' });
+    expect(mockedMakeRequest).toHaveBeenCalledWith('POST', expect.any(String), {}, { verse_key: '1:1' });
+  });
+});
+
+describe('Bookmark handlers', () => {
+  it('returns error on validation failure', async () => {
+    const result = await handleAddBookmark({});
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add AUTH_TOKEN and CLIENT_ID config variables
- refactor base service to generic makeRequest helper
- update all services to use makeRequest
- implement bookmark schemas, service and handlers
- expose new bookmark tools and wire them into the server
- provide bookmark tool examples and docs
- add unit tests for bookmark service and handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aaa4f8fcc83319475b87ade9693e4